### PR TITLE
Change voucher redeem API to be accessed with PATCH method

### DIFF
--- a/src/Traits/Routes.php
+++ b/src/Traits/Routes.php
@@ -38,7 +38,7 @@ trait Routes
                 RecipientsController::class .':getVoucherByEmail');
 
             // Redeem a voucher of a specific recipient
-            $this->put('/recipients/{email}/vouchers/{code}',
+            $this->patch('/recipients/{email}/vouchers/{code}',
                 RecipientsController::class .':redeemVoucherByEmail');
         });
     }

--- a/tests/VoucherTest.php
+++ b/tests/VoucherTest.php
@@ -235,7 +235,7 @@ class VoucherTest extends APIBaseTestCase
 
         $email = $recipient->email;
         $code = $vouchers[0]->code;
-        $response = $this->runApp('PUT', '/api/v1/recipients/'. $email .'/vouchers/'. $code);
+        $response = $this->runApp('PATCH', '/api/v1/recipients/'. $email .'/vouchers/'. $code);
         $voucher = json_decode((string)$response->getBody());
 
         $this->assertEquals(200, $response->getStatusCode());
@@ -254,7 +254,7 @@ class VoucherTest extends APIBaseTestCase
 
         $email = $recipient->email;
         $code = $vouchers[0]->code .'XYZ';
-        $response = $this->runApp('PUT', '/api/v1/recipients/'. $email .'/vouchers/'. $code);
+        $response = $this->runApp('PATCH', '/api/v1/recipients/'. $email .'/vouchers/'. $code);
         $responseJson = json_decode((string)$response->getBody());
 
         $this->assertEquals(404, $response->getStatusCode());
@@ -272,7 +272,7 @@ class VoucherTest extends APIBaseTestCase
 
         $email = $recipient->email. 'XYZ';
         $code = $vouchers[0]->code;
-        $response = $this->runApp('PUT', '/api/v1/recipients/'. $email .'/vouchers/'. $code);
+        $response = $this->runApp('PATCH', '/api/v1/recipients/'. $email .'/vouchers/'. $code);
         $responseJson = json_decode((string)$response->getBody());
 
         $this->assertEquals(404, $response->getStatusCode());


### PR DESCRIPTION
In the initial version, redeeming a voucher method was called with a PUT request. It should be replaced with PATCH.